### PR TITLE
Dev

### DIFF
--- a/src/pyuncertainnumber/characterisation/uncertainNumber.py
+++ b/src/pyuncertainnumber/characterisation/uncertainNumber.py
@@ -1101,11 +1101,6 @@ def truncexpon(*args):
 
 
 @makeUNPbox
-def truncnorm(*args):
-    return "truncnorm"
-
-
-@makeUNPbox
 def truncpareto(*args):
     return "truncpareto"
 

--- a/src/pyuncertainnumber/pba/pbox_abc.py
+++ b/src/pyuncertainnumber/pba/pbox_abc.py
@@ -631,9 +631,14 @@ class Staircase(Pbox):
             y=self.right, x=self._pvalues
         )
 
-    def truncate(self, a, b, method="f"):
-        """Equivalent to self.min(a,method).max(b,method)"""
-        return self.min(a, method=method).max(b, method=method)
+    def truncate(self, a, b):
+        from .aggregation import _imposition
+        from .pbox_free import min_max
+
+        """Truncate the Pbox to the range [a, b]."""
+        # return self.min(a, method=method).max(b, method=method)
+        i = min_max(a, b, return_construct=True)
+        return _imposition(self, i)
 
     def min(self, other, method="f"):
         """Returns a new Pbox object that represents the element-wise minimum of two Pboxes.
@@ -738,7 +743,9 @@ class Staircase(Pbox):
         d = []
         for sL, sR, oL, oR in zip(self.left, self.right, other.left, other.right):
             if max(sL, oL) > min(sR, oR):
-                raise Exception("Imposition does not exist")
+                raise Exception(
+                    "Imposition does not exist as high left greater than low right"
+                )
             u.append(max(sL, oL))
             d.append(min(sR, oR))
         return Staircase(left=u, right=d)

--- a/src/pyuncertainnumber/pba/pbox_parametric.py
+++ b/src/pyuncertainnumber/pba/pbox_parametric.py
@@ -1028,7 +1028,6 @@ named_pbox = {
     "trapz": trapz,
     "triang": triang,
     "truncexpon": truncexpon,
-    "truncnorm": truncnorm,
     "tukeylambda": tukeylambda,
     "uniform": uniform,
     "vonmises": vonmises,


### PR DESCRIPTION
Fixed `truncnorm` support issue. The correct way is to create a pbox and then truncate it.